### PR TITLE
Fix/hide hosted version copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1-alpha] - 2020-05-31
+## [v0.0.1-alpha] - 2020-05-31
 ### Added
 - Initial commit, docs, README and CHANGELOG.
 - Release config for publishing archives and binaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [v0.0.1-alpha] - 2020-05-31
+
 ### Added
 - Initial commit, docs, README and CHANGELOG.
 - Release config for publishing archives and binaries.

--- a/_web/src/auth/Auth.jsx
+++ b/_web/src/auth/Auth.jsx
@@ -16,8 +16,6 @@ const Auth = ({ signInHandler, signUpHandler, isSigningIn, isSigningUp, signInEr
         <img src='kenza_logo.svg' />
       </header>
       <p>{formTitle(isSignUpMode)}</p>
-      {isSignUpMode && <p>While Kenza is in a limited preview release, a new batch of invites will be sent out weekly.</p>}
-      {isSignUpMode && <p> Sign up to be added to the waitlist.</p>}
       {signInError && <section className='auth-notification'>{signInError}</section>}
       {signUpError && <section className='auth-notification'>{signUpError}</section>}
       <form className='auth-form'>
@@ -102,7 +100,7 @@ const mainActionButtonTitle = (isSigningIn, isSigningUp, signUpMode) => {
 }
 
 const formTitle = signUpMode => (
-    signUpMode ? 'Sign up for the Private Alpha' : 'Hi there, come on in!'
+    signUpMode ? 'Sign up for a Kenza account' : 'Hi there, come on in!'
 )
 
 const toggleModePromptTitle = signUpMode => (


### PR DESCRIPTION
Hide some copy on the signup page that was intended for the hosted version of Kenza.