### PR TITLE
Fix local dev setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.0.1-alpha] - 2020-05-31
+## [v0.0.1-alpha] - 2020-05-31
 ### Added
 - Initial commit, docs, README and CHANGELOG.
 - Release config for publishing archives and binaries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ## [v0.0.1-alpha] - 2020-05-31
+
 ### Added
 - Initial commit, docs, README and CHANGELOG.
 - Release config for publishing archives and binaries.

--- a/api_key.secret
+++ b/api_key.secret
@@ -1,0 +1,1 @@
+dummy_api_key_for_use_during_development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       - api
       - pubsub
     volumes:
+      - ./api_key.secret:/run/secrets/api_key
       - /var/run/docker.sock:/var/run/docker.sock # use host's docker
       - ${KENZA_JOB_LOGS_HOST_PATH}:${KENZA_JOB_LOGS_CONTAINER_PATH}:rw
       - ${KENZA_AWS_CONFIG_HOST_PATH}:${KENZA_WORKER_AWS_CONFIG_CONTAINER_PATH}:ro
@@ -78,6 +79,9 @@ services:
     depends_on:
       - api
       - pubsub
+    volumes:
+      - ./api_key.secret:/run/secrets/api_key
+  
 
   api:
     init: true
@@ -114,6 +118,7 @@ services:
       - db
       - pubsub
     volumes:
+      - ./api_key.secret:/run/secrets/api_key
       - ${KENZA_JOB_LOGS_HOST_PATH}:${KENZA_JOB_LOGS_CONTAINER_PATH}:ro
       - ${KENZA_AWS_CONFIG_HOST_PATH}:${KENZA_API_AWS_CONFIG_CONTAINER_PATH}:ro
       - ${KENZA_AWS_CREDENTIALS_HOST_PATH}:${KENZA_API_AWS_CREDENTIALS_CONTAINER_PATH}:ro
@@ -135,6 +140,8 @@ services:
     depends_on:
       - api
       - pubsub
+    volumes:
+      - ./api_key.secret:/run/secrets/api_key
 
   web:
     init: true


### PR DESCRIPTION
Developing locally was recently broken with the introduction of _Docker_ secrets. This brings the local dev setup, that uses `docker-compose` commands instead of _Swarm_ ones, on parity with local and cloud deployment setups.